### PR TITLE
Replace fizz buzz with prime numbers in UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Mini Code Golf - Lightweight Specification
 
 ## Overview
-A lightweight web app for team-based code golf competitions with Supabase backend. Teams approach terminals, enter their name, solve Fizz Buzz, and compete on a leaderboard.
+A lightweight web app for team-based code golf competitions with Supabase backend. Teams approach terminals, enter their name, solve a prime numbers challenge, and compete on a leaderboard.
 
-## Selected Problem: Fizz Buzz
-Print numbers 1 to 100, but replace multiples of 3 with "Fizz", multiples of 5 with "Buzz", and multiples of both with "FizzBuzz".
+## Selected Problem: Prime Numbers
+Print all prime numbers from 1 to 100, one per line.
 
 ## Tech Stack (Lightweight)
 - **Frontend**: React + TypeScript + Vite

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mini Code Golf
 
-A lightweight web application for running team-based code golf competitions during hackathons. Teams solve the classic Fizz Buzz problem in the fewest characters possible using JavaScript.
+A lightweight web application for running team-based code golf competitions during hackathons. Teams now solve a prime numbers challenge in the fewest characters possible using JavaScript.
 
 ## Features
 
@@ -134,7 +134,7 @@ A lightweight web application for running team-based code golf competitions duri
 ### For Participants
 
 1. Enter team category (1 or 2) and team number
-2. Write your JavaScript Fizz Buzz solution in the Monaco editor
+2. Write your JavaScript prime numbers solution in the Monaco editor
 3. Use **Shift+Enter** to run and see output in console
 4. Use **Alt+T** to test solution correctness
 5. Use **Alt+S** to submit when ready
@@ -142,10 +142,7 @@ A lightweight web application for running team-based code golf competitions duri
 
 ## The Challenge
 
-Write a program that prints numbers from 1 to 100, but:
-- For multiples of 3, print "Fizz"
-- For multiples of 5, print "Buzz"
-- For multiples of both 3 and 5, print "FizzBuzz"
+Write a program that prints all prime numbers from 1 to 100, one per line.
 
 ## Deployment
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Code Golf Challenge - Fizz Buzz</title>
+    <title>Code Golf Challenge - Prime Numbers</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -98,7 +98,7 @@ function Leaderboard() {
           <h1 className="text-7xl font-bold mb-4 bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500 bg-clip-text text-transparent">
             🏆 CODE GOLF LEADERBOARD 🏆
           </h1>
-          <p className="text-2xl text-gray-300">JavaScript Fizz Buzz Challenge</p>
+          <p className="text-2xl text-gray-300">JavaScript Prime Numbers Challenge</p>
           <p className="text-lg text-gray-400 mt-2">Shortest code wins!</p>
         </div>
 

--- a/supabase/functions/execute-code/README.md
+++ b/supabase/functions/execute-code/README.md
@@ -39,9 +39,9 @@ This Edge Function executes Python and JavaScript code submissions for the Code 
 
 3. Test with curl:
    ```bash
-   curl -i --location --request POST 'http://localhost:54321/functions/v1/execute-code' \
-     --header 'Content-Type: application/json' \
-     --data '{"code":"for(let i=1;i<=100;i++){console.log(i%15==0?\"FizzBuzz\":i%3==0?\"Fizz\":i%5==0?\"Buzz\":i)}","language":"javascript"}'
+    curl -i --location --request POST 'http://localhost:54321/functions/v1/execute-code' \
+      --header 'Content-Type: application/json' \
+      --data '{"code":"for(let n=2;n<=100;n++){let p=true;for(let i=2;i<n;i++)if(n%i==0){p=false;break;}if(p)console.log(n)}","language":"javascript"}'
    ```
 
 ## Notes
@@ -49,4 +49,4 @@ This Edge Function executes Python and JavaScript code submissions for the Code 
 - JavaScript execution uses sandboxed Function constructor
 - Python execution requires Python 3 in the Supabase Edge Runtime
 - Output is limited to 500 characters for safety
-- Validates against expected Fizz Buzz output
+- Validates against expected prime numbers output


### PR DESCRIPTION
## Summary
- update main page title to Prime Numbers
- update leaderboard text
- update README and Supabase function docs for prime numbers
- tweak CLAUDE design doc intro

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68482369a238832eb452ae9f870d0edb